### PR TITLE
Fix short circuiting deepEqual

### DIFF
--- a/assertive-chai.js
+++ b/assertive-chai.js
@@ -165,8 +165,8 @@
     if (typeOf(expected) === 'date') {
       expected = expected.getTime();
     }
-    return assert.equal(typeOf(actual), typeOf(expected), msg) &&
-      assert.deepEqual(actual, expected, msg);
+    assert.equal(typeOf(actual), typeOf(expected), msg);
+    return assert.deepEqual(actual, expected, msg);
   };
 
   chai.assert.notDeepEqual = function (actual, expected, msg) {


### PR DESCRIPTION
assert.equal returns undefined in Jxck's library, so doing:

```
assert.equal && <SOME EXPRESSION>
```

would short-circuit previously. I've fixed this issue
